### PR TITLE
Criando botões que usam as primary colors

### DIFF
--- a/src/style/components/btn.styl
+++ b/src/style/components/btn.styl
@@ -124,3 +124,56 @@
 .btn.gmd.fab .material-icons
   font-size: 24px
   color: #fff
+  
+  .btn.gmd.raised.btn-primary-color
+  color: #fff
+  background-color: colors.primary
+  opacity: .9
+  &:hover
+    opacity: 1
+
+.btn.gmd.raised.btn-primary-color-light 
+  color: #fff
+  background-color: colors.lightPrimary
+  opacity: .9
+  &:hover
+    opacity: 1
+
+.btn.gmd.raised.btn-primary-color-dark 
+  color: #fff
+  background-color: colors.darkPrimary
+  opacity: .9
+  &:hover
+    opacity: 1
+
+.btn.gmd.btn-primary-color 
+  color: colors.primary
+  background-color: transparent
+  &:hover
+    color: #fff
+    background-color: colors.primary
+
+.btn.gmd.btn-primary-color-light 
+  color: colors.lightPrimary
+  background-color: transparent
+  &:hover
+    color: #fff
+    background-color: colors.lightPrimary
+
+
+.btn.gmd.btn-primary-color-dark 
+  color: colors.darkPrimary
+  background-color: transparent
+  &:hover
+    color: #fff
+    background-color: colors.darkPrimary   
+
+
+.btn.gmd.fab.btn-primary-color
+  background-color: colors.primary
+
+.btn.gmd.fab.btn-primary-color-light
+  background-color: colors.lightPrimary
+
+.btn.gmd.fab.btn-primary-color-dark
+  background-color: colors.darkPrimary


### PR DESCRIPTION
Criando botões (normal, raised e FAB) que além das cores do bootstrap utilizam as cores primary, primaryLight e primaryDark da palheta de cores escolhida.